### PR TITLE
Add possibility create empty setUp Thread Group

### DIFF
--- a/jmeter-java-dsl/src/main/java/us/abstracta/jmeter/javadsl/JmeterDsl.java
+++ b/jmeter-java-dsl/src/main/java/us/abstracta/jmeter/javadsl/JmeterDsl.java
@@ -192,25 +192,29 @@ public class JmeterDsl {
   }
 
   /**
-   * This allowing to set a name on the setup thread group.
+   * Same as {@link #setupThreadGroup(ThreadGroupChild...)} but allowing to set a name on the thread group.
+   *
+   * Allows setting the name on the setup thread group.
    * <p>
    * Setting a proper name allows to properly identify the requests generated in each thread group.
    *
    * @see DslSetupThreadGroup
-   * @since 0.33.2
+   * @since 0.35
    */
   public static DslSetupThreadGroup setupThreadGroup(String name, ThreadGroupChild... children) {
     return new DslSetupThreadGroup(name, Arrays.asList(children));
   }
 
   /**
-   * This allowing to create empty the setup thread group,
+   * Same as {@link #setupThreadGroup(ThreadGroupChild...)} but allowing to set nothing on the thread group.
+   *
+   * Allows to create the setup thread group with empty params,
    * which allows the item to be configured via '.children'.
    * <p>
    * Setting a proper name allows to properly identify the requests generated in each thread group.
    *
    * @see DslTeardownThreadGroup
-   * @since 0.33.2
+   * @since 0.35
    */
   public static DslSetupThreadGroup setupThreadGroup() {
     return new DslSetupThreadGroup("null", Collections.emptyList());
@@ -235,12 +239,14 @@ public class JmeterDsl {
   }
 
   /**
-   * This allowing to set a name on the teardown thread group.
+   * Same as {@link #teardownThreadGroup(ThreadGroupChild...)} but allowing to set a name on the thread group.
+   *
+   * Allows to set a name on the teardown thread group.
    * <p>
    * Setting a proper name allows to properly identify the requests generated in each thread group.
    *
    * @see DslTeardownThreadGroup
-   * @since 0.33.2
+   * @since 0.35
    */
   public static DslTeardownThreadGroup teardownThreadGroup(String name,
                                                            ThreadGroupChild... children) {
@@ -248,13 +254,15 @@ public class JmeterDsl {
   }
 
   /**
-   * This allowing to create empty the teardown thread group,
+   * Same as {@link #teardownThreadGroup(ThreadGroupChild...)} but allowing to set nothing on the thread group.
+   *
+   * Allows to create the teardown thread group with empty params,
    * which allows the item to be configured via '.children'.
    * <p>
    * Setting a proper name allows to properly identify the requests generated in each thread group.
    *
    * @see DslTeardownThreadGroup
-   * @since 0.33.2
+   * @since 0.35
    */
   public static DslTeardownThreadGroup teardownThreadGroup() {
     return new DslTeardownThreadGroup("null", Collections.emptyList());

--- a/jmeter-java-dsl/src/main/java/us/abstracta/jmeter/javadsl/JmeterDsl.java
+++ b/jmeter-java-dsl/src/main/java/us/abstracta/jmeter/javadsl/JmeterDsl.java
@@ -188,7 +188,32 @@ public class JmeterDsl {
    * @since 0.33
    */
   public static DslSetupThreadGroup setupThreadGroup(ThreadGroupChild... children) {
-    return new DslSetupThreadGroup(Arrays.asList(children));
+    return new DslSetupThreadGroup(null, Arrays.asList(children));
+  }
+
+  /**
+   * This allowing to set a name on the setup thread group.
+   * <p>
+   * Setting a proper name allows to properly identify the requests generated in each thread group.
+   *
+   * @see DslSetupThreadGroup
+   * @since 0.33.2
+   */
+  public static DslSetupThreadGroup setupThreadGroup(String name, ThreadGroupChild... children) {
+    return new DslSetupThreadGroup(name, Arrays.asList(children));
+  }
+
+  /**
+   * This allowing to create empty the setup thread group,
+   * which allows the item to be configured via '.children'.
+   * <p>
+   * Setting a proper name allows to properly identify the requests generated in each thread group.
+   *
+   * @see DslTeardownThreadGroup
+   * @since 0.33.2
+   */
+  public static DslSetupThreadGroup setupThreadGroup() {
+    return new DslSetupThreadGroup("null", Collections.emptyList());
   }
 
   /**
@@ -206,7 +231,33 @@ public class JmeterDsl {
    * @since 0.33
    */
   public static DslTeardownThreadGroup teardownThreadGroup(ThreadGroupChild... children) {
-    return new DslTeardownThreadGroup(Arrays.asList(children));
+    return new DslTeardownThreadGroup("null", Arrays.asList(children));
+  }
+
+  /**
+   * This allowing to set a name on the teardown thread group.
+   * <p>
+   * Setting a proper name allows to properly identify the requests generated in each thread group.
+   *
+   * @see DslTeardownThreadGroup
+   * @since 0.33.2
+   */
+  public static DslTeardownThreadGroup teardownThreadGroup(String name,
+                                                           ThreadGroupChild... children) {
+    return new DslTeardownThreadGroup(name, Arrays.asList(children));
+  }
+
+  /**
+   * This allowing to create empty the teardown thread group,
+   * which allows the item to be configured via '.children'.
+   * <p>
+   * Setting a proper name allows to properly identify the requests generated in each thread group.
+   *
+   * @see DslTeardownThreadGroup
+   * @since 0.33.2
+   */
+  public static DslTeardownThreadGroup teardownThreadGroup() {
+    return new DslTeardownThreadGroup("null", Collections.emptyList());
   }
 
   /**

--- a/jmeter-java-dsl/src/main/java/us/abstracta/jmeter/javadsl/core/threadgroups/DslSetupThreadGroup.java
+++ b/jmeter-java-dsl/src/main/java/us/abstracta/jmeter/javadsl/core/threadgroups/DslSetupThreadGroup.java
@@ -27,12 +27,8 @@ import org.apache.jmeter.threads.gui.SetupThreadGroupGui;
  */
 public class DslSetupThreadGroup extends DslSimpleThreadGroup<DslSetupThreadGroup> {
 
-  public DslSetupThreadGroup(List<ThreadGroupChild> children) {
-    super("setUp Thread Group", SetupThreadGroupGui.class, children);
-  }
-  
-  public DslSetupThreadGroup(String name) {
-    super(solveName(name), null, Collections.emptyList());
+  public DslSetupThreadGroup(String name, List<ThreadGroupChild> children) {
+    super(solveName(name), SetupThreadGroupGui.class, children);
   }
 
   private static String solveName(String name) {

--- a/jmeter-java-dsl/src/main/java/us/abstracta/jmeter/javadsl/core/threadgroups/DslSetupThreadGroup.java
+++ b/jmeter-java-dsl/src/main/java/us/abstracta/jmeter/javadsl/core/threadgroups/DslSetupThreadGroup.java
@@ -30,7 +30,15 @@ public class DslSetupThreadGroup extends DslSimpleThreadGroup<DslSetupThreadGrou
   public DslSetupThreadGroup(List<ThreadGroupChild> children) {
     super("setUp Thread Group", SetupThreadGroupGui.class, children);
   }
+  
+  public DslSetupThreadGroup(String name) {
+    super(solveName(name), null, Collections.emptyList());
+  }
 
+  private static String solveName(String name) {
+    return name != null ? name : "setUp Thread Group";
+  }
+  
   @Override
   protected AbstractThreadGroup buildSimpleThreadGroup() {
     return new SetupThreadGroup();

--- a/jmeter-java-dsl/src/main/java/us/abstracta/jmeter/javadsl/core/threadgroups/DslTeardownThreadGroup.java
+++ b/jmeter-java-dsl/src/main/java/us/abstracta/jmeter/javadsl/core/threadgroups/DslTeardownThreadGroup.java
@@ -27,8 +27,12 @@ import org.apache.jmeter.threads.gui.PostThreadGroupGui;
  */
 public class DslTeardownThreadGroup extends DslSimpleThreadGroup<DslSetupThreadGroup> {
 
-  public DslTeardownThreadGroup(List<ThreadGroupChild> children) {
-    super("tearDown Thread Group", PostThreadGroupGui.class, children);
+  public DslTeardownThreadGroup(String name, List<ThreadGroupChild> children) {
+    super(solveName(name), PostThreadGroupGui.class, children);
+  }
+
+  private static String solveName(String name) {
+    return name != null ? name : "tearDown Thread Group";
   }
 
   @Override


### PR DESCRIPTION
This is necessary for the uniform creation of trade groups within the DSL. So far, I propose only for this thread of the group, as an opinion.
I will use it for my custom builder.