### PR TITLE
Update pom.xml with Jmeter version upgrade 5.2.1 -> 5.4.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ If you use [maven](https://maven.apache.org/what-is-maven.html), just include fo
 <dependency>
   <groupId>us.abstracta.jmeter</groupId>
   <artifactId>jmeter-java-dsl</artifactId>
-  <version>0.35</version>
+  <version>0.36</version>
   <scope>test</scope>
 </dependency>
 ``` 

--- a/docs/guide/README.md
+++ b/docs/guide/README.md
@@ -29,7 +29,7 @@ To use the DSL just include it in your project:
 <dependency>
   <groupId>us.abstracta.jmeter</groupId>
   <artifactId>jmeter-java-dsl</artifactId>
-  <version>0.35</version>
+  <version>0.36</version>
   <scope>test</scope>
 </dependency>
 ```
@@ -50,7 +50,7 @@ class JmeterRule implements ComponentMetadataRule {
 
 dependencies {
     ...
-    testImplementation 'us.abstracta.jmeter:jmeter-java-dsl:0.35'
+    testImplementation 'us.abstracta.jmeter:jmeter-java-dsl:0.36'
     components {
         withModule("org.apache.jmeter:ApacheJMeter_core", JmeterRule)
         withModule("org.apache.jmeter:ApacheJMeter_java", JmeterRule)
@@ -129,14 +129,14 @@ By including following module as dependency:
 <dependency>
   <groupId>us.abstracta.jmeter</groupId>
   <artifactId>jmeter-java-dsl-blazemeter</artifactId>
-  <version>0.35</version>
+  <version>0.36</version>
   <scope>test</scope>
 </dependency>
 ```
 :::
 ::: tab Gradle
 ```groovy
-testImplementation 'us.abstracta.jmeter:jmeter-java-dsl-blazemeter:0.35'
+testImplementation 'us.abstracta.jmeter:jmeter-java-dsl-blazemeter:0.36'
 ```
 :::
 ::::
@@ -670,7 +670,7 @@ To use the module, you will need to include following dependency in your project
 <dependency>
   <groupId>us.abstracta.jmeter</groupId>
   <artifactId>jmeter-java-dsl-elasticsearch-listener</artifactId>
-  <version>0.35</version>
+  <version>0.36</version>
   <scope>test</scope>
 </dependency>
 ```
@@ -683,7 +683,7 @@ maven { url 'https://jitpack.io' }
 
 And the dependency:
 ```groovy
-testImplementation 'us.abstracta.jmeter:jmeter-java-dsl-elasticsearch-listener:0.35'
+testImplementation 'us.abstracta.jmeter:jmeter-java-dsl-elasticsearch-listener:0.36'
 ```
 
 :::
@@ -783,14 +783,14 @@ To use it, you need to add following dependency:
 <dependency>
   <groupId>us.abstracta.jmeter</groupId>
   <artifactId>jmeter-java-dsl-dashboard</artifactId>
-  <version>0.35</version>
+  <version>0.36</version>
   <scope>test</scope>
 </dependency>
 ```
 :::
 ::: tab Gradle
 ```groovy
-testImplementation 'us.abstracta.jmeter:jmeter-java-dsl-dashboard:0.35'
+testImplementation 'us.abstracta.jmeter:jmeter-java-dsl-dashboard:0.36'
 ```
 :::
 ::::
@@ -1531,14 +1531,14 @@ To use it, add following dependency to your project:
 <dependency>
   <groupId>us.abstracta.jmeter</groupId>
   <artifactId>jmeter-java-dsl-parallel</artifactId>
-  <version>0.35</version>
+  <version>0.36</version>
   <scope>test</scope>
 </dependency>
 ```
 :::
 ::: tab Gradle
 ```groovy
-testImplementation 'us.abstracta.jmeter:jmeter-java-dsl-dashboard:0.35'
+testImplementation 'us.abstracta.jmeter:jmeter-java-dsl-dashboard:0.36'
 ```
 :::
 ::::

--- a/docs/index.md
+++ b/docs/index.md
@@ -20,7 +20,7 @@ Add dependency to your project:
 <dependency>
   <groupId>us.abstracta.jmeter</groupId>
   <artifactId>jmeter-java-dsl</artifactId>
-  <version>0.35</version>
+  <version>0.36</version>
   <scope>test</scope>
 </dependency>
 ```

--- a/jmeter-java-dsl/pom.xml
+++ b/jmeter-java-dsl/pom.xml
@@ -18,7 +18,7 @@
   </description>
 
   <properties>
-    <jmeter.version>5.2.1</jmeter.version>
+    <jmeter.version>5.4.1</jmeter.version>
   </properties>
 
   <dependencies>

--- a/jmeter-java-dsl/src/main/java/us/abstracta/jmeter/javadsl/core/DslStatisticsSummaryData.java
+++ b/jmeter-java-dsl/src/main/java/us/abstracta/jmeter/javadsl/core/DslStatisticsSummaryData.java
@@ -1,0 +1,129 @@
+package us.abstracta.jmeter.javadsl.core;
+
+import org.apache.jmeter.report.processor.MeanAggregator;
+import org.apache.jmeter.report.processor.PercentileAggregator;
+import org.apache.jmeter.report.processor.StatisticsSummaryData;
+
+public class DslStatisticsSummaryData extends StatisticsSummaryData {
+
+	private final PercentileAggregator latencyPercentile1;
+	private final PercentileAggregator latencyPercentile2;
+	private final PercentileAggregator latencyPercentile3;
+	private final MeanAggregator latencyMean;
+	private final PercentileAggregator latencyMedian;
+	private final PercentileAggregator processingPercentile1;
+	private final PercentileAggregator processingPercentile2;
+	private final PercentileAggregator processingPercentile3;
+	private final MeanAggregator processingMean;
+	private final PercentileAggregator processingMedian;
+	private long latencyMin = 9223372036854775807L;
+	private long latencyMax = -9223372036854775808L;
+	private long processingMin = 9223372036854775807L;
+	private long processingMax = -9223372036854775808L;
+	private long latency = 0L;
+	private long processing = 0L;
+
+	public DslStatisticsSummaryData(double percentileIndex1, double percentileIndex2,
+	                                double percentileIndex3) {
+		super(percentileIndex1, percentileIndex2, percentileIndex3);
+		this.latencyPercentile1 = new PercentileAggregator(percentileIndex1);
+		this.latencyPercentile2 = new PercentileAggregator(percentileIndex2);
+		this.latencyPercentile3 = new PercentileAggregator(percentileIndex3);
+		this.latencyMean = new MeanAggregator();
+		this.latencyMedian = new PercentileAggregator(50.0D);
+		this.processingPercentile1 = new PercentileAggregator(percentileIndex1);
+		this.processingPercentile2 = new PercentileAggregator(percentileIndex2);
+		this.processingPercentile3 = new PercentileAggregator(percentileIndex3);
+		this.processingMean = new MeanAggregator();
+		this.processingMedian = new PercentileAggregator(50.0D);
+	}
+
+	public final PercentileAggregator getLatencyPercentile1() {
+		return this.latencyPercentile1;
+	}
+
+	public final PercentileAggregator getLatencyPercentile2() {
+		return this.latencyPercentile2;
+	}
+
+	public final PercentileAggregator getLatencyPercentile3() {
+		return this.latencyPercentile3;
+	}
+
+	public MeanAggregator getLatencyMean() {
+		return this.latencyMean;
+	}
+
+	public PercentileAggregator getLatencyMedian() {
+		return this.latencyMedian;
+	}
+
+	public final PercentileAggregator getProcessingPercentile1() {
+		return this.processingPercentile1;
+	}
+
+	public final PercentileAggregator getProcessingPercentile2() {
+		return this.processingPercentile2;
+	}
+
+	public final PercentileAggregator getProcessingPercentile3() {
+		return this.processingPercentile3;
+	}
+
+	public MeanAggregator getProcessingMean() {
+		return this.processingMean;
+	}
+
+	public PercentileAggregator getProcessingMedian() {
+		return this.processingMedian;
+	}
+
+	public final long getLatencyMin() {
+		return this.latencyMin;
+	}
+
+	public final void setLatencyMin(long min) {
+		this.latencyMin = Math.min(this.latencyMin, min);
+	}
+
+	public final long getLatencyMax() {
+		return this.latencyMax;
+	}
+
+	public final void setLatencyMax(long max) {
+		this.latencyMax = Math.max(this.latencyMax, max);
+	}
+
+	public final long getProcessingMin() {
+		return this.processingMin;
+	}
+
+	public final void setProcessingMin(long min) {
+		this.processingMin = Math.min(this.processingMin, min);
+	}
+
+	public final long getProcessingMax() {
+		return this.processingMax;
+	}
+
+	public final void setProcessingMax(long max) {
+		this.processingMax = Math.max(this.processingMax, max);
+	}
+
+	public final void setLatency(long latency) {
+		this.latency = latency;
+	}
+
+	public final long getLatencyTime() {
+		return this.latency;
+	}
+
+	public final void setProcessing(long processing) {
+		this.processing = processing;
+	}
+
+	public final long getProcessingTime() {
+		return this.processing;
+	}
+
+}

--- a/jmeter-java-dsl/src/main/java/us/abstracta/jmeter/javadsl/core/TestPlanStats.java
+++ b/jmeter-java-dsl/src/main/java/us/abstracta/jmeter/javadsl/core/TestPlanStats.java
@@ -136,6 +136,145 @@ public class TestPlanStats {
      */
     double sentBytesPerSecond();
 
+    /**
+     * Gets the duration from jmeter send request to jmeter
+     * get the first batch of response (like TTFB).
+     *
+     * @since 0.37
+     */
+    Duration latencyTime();
+
+    /**
+     * Get the the minimum latency time of sampler.
+     *
+     * Based on {@link #latencyTime()}
+     *
+     * @since 0.37
+     */
+    Duration minSampleLatencyTime();
+
+    /**
+     * Get the the maximum latency time of sampler.
+     *
+     * Based on {@link #latencyTime()}
+     *
+     * @since 0.37
+     */
+    Duration maxSampleLatencyTime();
+
+    /**
+     * Get the the average latency time of sampler.
+     *
+     * Based on {@link #latencyTime()}
+     *
+     * @since 0.37
+     */
+    Duration meanSampleLatencyTime();
+
+    /**
+     * Gets the 90 percentile of samples latencies time.
+     *
+     * 90% of samples latency time took less or equal to the returned value.
+     *
+     * Based on {@link #latencyTime()}
+     *
+     * @since 0.37
+     */
+    Duration sampleLatencyTimePercentile90();
+
+    /**
+     * Gets the 95 percentile of samples latencies time.
+     *
+     * 95% of samples latency time took less or equal to the returned value.
+     *
+     * Based on {@link #latencyTime()}
+     *
+     * @since 0.37
+     */
+    Duration sampleLatencyTimePercentile95();
+
+    /**
+     * Gets the 99 percentile of samples latencies time.
+     *
+     * 99% of samples latency time took less or equal to the returned value.
+     *
+     * Based on {@link #latencyTime()}
+     */
+    Duration sampleLatencyTimePercentile99();
+
+    /**
+     * Gets the duration of difference between elapsed time and latency time.
+     *
+     * With the degradation of the productivity of JMeter itself - this metric is able to show
+     * what is the longest part of its work.
+     *
+     * Based on {@link #elapsedTime()}-{@link #latencyTime()}
+     *
+     * @since 0.37
+     */
+    Duration processingTime();
+
+    /**
+     * Get the the minimum processing time of sampler.
+     *
+     * Based on {@link #processingTime()}
+     *
+     * @since 0.37
+     */
+    Duration minSampleProcessingTime();
+
+    /**
+     * Get the the maximum processing time of sampler.
+     *
+     * Based on {@link #processingTime()}
+     *
+     * @since 0.37
+     */
+    Duration maxSampleProcessingTime();
+
+    /**
+     * Get the the average processing time of sampler.
+     *
+     * Based on {@link #processingTime()}
+     *
+     * @since 0.37
+     */
+    Duration meanSampleProcessingTime();
+
+    /**
+     * Gets the 90 percentile of samples processing time.
+     *
+     * 90% of samples processing time took less or equal to the returned value.
+     *
+     * Based on {@link #processingTime()}
+     *
+     * @since 0.37
+     */
+    Duration sampleProcessingTimePercentile90();
+
+    /**
+     * Gets the 95 percentile of samples processing time.
+     *
+     * 95% of samples processing time took less or equal to the returned value.
+     *
+     * Based on {@link #processingTime()}
+     *
+     * @since 0.37
+     */
+    Duration sampleProcessingTimePercentile95();
+
+    /**
+     * Gets the 99 percentile of samples processing time.
+     *
+     * 99% of samples processing time took less or equal to the returned value.
+     *
+     * Based on {@link #processingTime()}
+     *
+     * @since 0.37
+     */
+
+    Duration sampleProcessingTimePercentile99();
+
   }
 
   public void setLabeledStats(String label, StatsSummary stats) {

--- a/jmeter-java-dsl/src/main/java/us/abstracta/jmeter/javadsl/core/engines/AggregatingTestPlanStats.java
+++ b/jmeter-java-dsl/src/main/java/us/abstracta/jmeter/javadsl/core/engines/AggregatingTestPlanStats.java
@@ -2,8 +2,8 @@ package us.abstracta.jmeter.javadsl.core.engines;
 
 import java.time.Duration;
 import java.time.Instant;
-import org.apache.jmeter.report.processor.StatisticsSummaryData;
 import org.apache.jmeter.samplers.SampleResult;
+import us.abstracta.jmeter.javadsl.core.DslStatisticsSummaryData;
 import us.abstracta.jmeter.javadsl.core.TestPlanStats;
 
 /**
@@ -25,7 +25,7 @@ public class AggregatingTestPlanStats extends TestPlanStats {
 
   public static class AggregatingStatsSummary implements StatsSummary {
 
-    private final StatisticsSummaryData stats = new StatisticsSummaryData(90, 95, 99);
+    private final DslStatisticsSummaryData stats = new DslStatisticsSummaryData(90, 95, 99);
 
     private void setStart(Instant start) {
       stats.setFirstTime(start.toEpochMilli());
@@ -43,6 +43,10 @@ public class AggregatingTestPlanStats extends TestPlanStats {
         stats.incErrors();
       }
       updateElapsedTime(result.getTime());
+      updateLatencyTime(result.getLatency());
+      updateProcessingTime(result.getTime() - result.getLatency());
+      stats.setLatency(result.getLatency());
+      stats.setProcessing(result.getTime() - result.getLatency());
       stats.setFirstTime(result.getStartTime());
       stats.setEndTime(result.getEndTime());
     }
@@ -52,8 +56,30 @@ public class AggregatingTestPlanStats extends TestPlanStats {
       stats.getPercentile2().addValue(elapsedTime);
       stats.getPercentile3().addValue(elapsedTime);
       stats.getMean().addValue(elapsedTime);
+      stats.getMedian().addValue(elapsedTime);
       stats.setMin(elapsedTime);
       stats.setMax(elapsedTime);
+    }
+
+    private void updateLatencyTime(long latencyTime) {
+      stats.getLatencyPercentile1().addValue(latencyTime);
+      stats.getLatencyPercentile2().addValue(latencyTime);
+      stats.getLatencyPercentile3().addValue(latencyTime);
+      stats.getLatencyMean().addValue(latencyTime);
+      stats.getLatencyMedian().addValue(latencyTime);
+      stats.setLatencyMin(latencyTime);
+      stats.setLatencyMax(latencyTime);
+      stats.setLatencyMax(latencyTime);
+    }
+
+    private void updateProcessingTime(long processingTime) {
+      stats.getProcessingPercentile1().addValue(processingTime);
+      stats.getProcessingPercentile2().addValue(processingTime);
+      stats.getProcessingPercentile3().addValue(processingTime);
+      stats.getProcessingMean().addValue(processingTime);
+      stats.getProcessingMedian().addValue(processingTime);
+      stats.setProcessingMin(processingTime);
+      stats.setProcessingMax(processingTime);
     }
 
     @Override
@@ -134,6 +160,76 @@ public class AggregatingTestPlanStats extends TestPlanStats {
     @Override
     public double sentBytesPerSecond() {
       return stats.getSentBytesPerSecond();
+    }
+
+    @Override
+    public Duration minSampleLatencyTime() {
+      return Duration.ofMillis(stats.getLatencyMin());
+    }
+    
+    @Override
+    public Duration maxSampleLatencyTime() {
+      return Duration.ofMillis(stats.getLatencyMax());
+    }
+
+    @Override
+    public Duration meanSampleLatencyTime() {
+      return Duration.ofMillis((long) stats.getLatencyMean().getResult());
+    }
+
+    @Override
+    public Duration sampleLatencyTimePercentile90() {
+      return Duration.ofMillis((long) stats.getLatencyPercentile1().getResult());
+    }
+
+    @Override
+    public Duration sampleLatencyTimePercentile95() {
+      return Duration.ofMillis((long) stats.getLatencyPercentile2().getResult());
+    }
+
+    @Override
+    public Duration sampleLatencyTimePercentile99() {
+      return Duration.ofMillis((long) stats.getLatencyPercentile3().getResult());
+    }
+
+    @Override
+    public Duration minSampleProcessingTime() {
+      return Duration.ofMillis(stats.getProcessingMin());
+    }
+
+    @Override
+    public Duration maxSampleProcessingTime() {
+      return Duration.ofMillis(stats.getProcessingMax());
+    }
+
+    @Override
+    public Duration meanSampleProcessingTime() {
+      return Duration.ofMillis((long) stats.getProcessingMean().getResult());
+    }
+
+    @Override
+    public Duration sampleProcessingTimePercentile90() {
+      return Duration.ofMillis((long) stats.getProcessingPercentile1().getResult());
+    }
+
+    @Override
+    public Duration sampleProcessingTimePercentile95() {
+      return Duration.ofMillis((long) stats.getProcessingPercentile2().getResult());
+    }
+
+    @Override
+    public Duration sampleProcessingTimePercentile99() {
+      return Duration.ofMillis((long) stats.getProcessingPercentile3().getResult());
+    }
+
+    @Override
+    public Duration processingTime() {
+      return Duration.ofMillis(stats.getProcessingTime());
+    }
+
+    @Override
+    public Duration latencyTime() {
+      return Duration.ofMillis(stats.getLatencyTime());
     }
 
   }


### PR DESCRIPTION
In practice, it turned out that a more recent version of JMeter is required to use a higher version of Java (eg 16). It's all about libraries and their compatibility. This seems to be a pretty important reason to update the version in a timely manner.