### PR TITLE
Extending TestPlanStats functionality adding latency and processing time with aggregators

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ If you use [maven](https://maven.apache.org/what-is-maven.html), just include fo
 <dependency>
   <groupId>us.abstracta.jmeter</groupId>
   <artifactId>jmeter-java-dsl</artifactId>
-  <version>0.35</version>
+  <version>0.36</version>
   <scope>test</scope>
 </dependency>
 ``` 

--- a/docs/guide/README.md
+++ b/docs/guide/README.md
@@ -29,7 +29,7 @@ To use the DSL just include it in your project:
 <dependency>
   <groupId>us.abstracta.jmeter</groupId>
   <artifactId>jmeter-java-dsl</artifactId>
-  <version>0.35</version>
+  <version>0.36</version>
   <scope>test</scope>
 </dependency>
 ```
@@ -50,7 +50,7 @@ class JmeterRule implements ComponentMetadataRule {
 
 dependencies {
     ...
-    testImplementation 'us.abstracta.jmeter:jmeter-java-dsl:0.35'
+    testImplementation 'us.abstracta.jmeter:jmeter-java-dsl:0.36'
     components {
         withModule("org.apache.jmeter:ApacheJMeter_core", JmeterRule)
         withModule("org.apache.jmeter:ApacheJMeter_java", JmeterRule)
@@ -129,14 +129,14 @@ By including following module as dependency:
 <dependency>
   <groupId>us.abstracta.jmeter</groupId>
   <artifactId>jmeter-java-dsl-blazemeter</artifactId>
-  <version>0.35</version>
+  <version>0.36</version>
   <scope>test</scope>
 </dependency>
 ```
 :::
 ::: tab Gradle
 ```groovy
-testImplementation 'us.abstracta.jmeter:jmeter-java-dsl-blazemeter:0.35'
+testImplementation 'us.abstracta.jmeter:jmeter-java-dsl-blazemeter:0.36'
 ```
 :::
 ::::
@@ -670,7 +670,7 @@ To use the module, you will need to include following dependency in your project
 <dependency>
   <groupId>us.abstracta.jmeter</groupId>
   <artifactId>jmeter-java-dsl-elasticsearch-listener</artifactId>
-  <version>0.35</version>
+  <version>0.36</version>
   <scope>test</scope>
 </dependency>
 ```
@@ -683,7 +683,7 @@ maven { url 'https://jitpack.io' }
 
 And the dependency:
 ```groovy
-testImplementation 'us.abstracta.jmeter:jmeter-java-dsl-elasticsearch-listener:0.35'
+testImplementation 'us.abstracta.jmeter:jmeter-java-dsl-elasticsearch-listener:0.36'
 ```
 
 :::
@@ -783,14 +783,14 @@ To use it, you need to add following dependency:
 <dependency>
   <groupId>us.abstracta.jmeter</groupId>
   <artifactId>jmeter-java-dsl-dashboard</artifactId>
-  <version>0.35</version>
+  <version>0.36</version>
   <scope>test</scope>
 </dependency>
 ```
 :::
 ::: tab Gradle
 ```groovy
-testImplementation 'us.abstracta.jmeter:jmeter-java-dsl-dashboard:0.35'
+testImplementation 'us.abstracta.jmeter:jmeter-java-dsl-dashboard:0.36'
 ```
 :::
 ::::
@@ -1531,14 +1531,14 @@ To use it, add following dependency to your project:
 <dependency>
   <groupId>us.abstracta.jmeter</groupId>
   <artifactId>jmeter-java-dsl-parallel</artifactId>
-  <version>0.35</version>
+  <version>0.36</version>
   <scope>test</scope>
 </dependency>
 ```
 :::
 ::: tab Gradle
 ```groovy
-testImplementation 'us.abstracta.jmeter:jmeter-java-dsl-dashboard:0.35'
+testImplementation 'us.abstracta.jmeter:jmeter-java-dsl-dashboard:0.36'
 ```
 :::
 ::::

--- a/docs/index.md
+++ b/docs/index.md
@@ -20,7 +20,7 @@ Add dependency to your project:
 <dependency>
   <groupId>us.abstracta.jmeter</groupId>
   <artifactId>jmeter-java-dsl</artifactId>
-  <version>0.35</version>
+  <version>0.36</version>
   <scope>test</scope>
 </dependency>
 ```

--- a/jmeter-java-dsl/src/main/java/us/abstracta/jmeter/javadsl/core/TestPlanStats.java
+++ b/jmeter-java-dsl/src/main/java/us/abstracta/jmeter/javadsl/core/TestPlanStats.java
@@ -135,6 +135,11 @@ public class TestPlanStats {
      * This is just {@link #sentBytes()}/{@link #elapsedTime()}.
      */
     double sentBytesPerSecond();
+    
+     /**
+     * Gets the latency
+     */
+    Duration Latency();
 
   }
 


### PR DESCRIPTION
We all want our tests to show honest results. There are many reasons why elapsed time does not show reality well enough.

There are a number of problems here:
1. While studying most of my large and complex tests, I came across a problem that the difference between Latency Time and Elapsed Time can be more than a minute. This could be caused by a long read from a socket or other post-processing. Most often, this problem occurs in the framework of the lack of Heap size or too long GC work.
2. Observability - jmeter has it at an insufficient level. Comparing analogs, for example
https://k6.io/docs/using-k6/metrics/#http-specific-built-in-metrics
has many more metrics for analyzing the situation. Why is TTFB important?
Because we measure in our tests the performance of the backend of our application and it is TTFB that is closest to the metrics of the application itself (+ network)
3. It can also sound like a good base for implementing high-quality autostop logic and give more flexible assertions. After all, these are tests, and tests must show compliance with the requirements or not. This is one of the patterns of why people choose Taurus - there is excellent control over the test, which will allow you to run a lot of tests and not study them in detail, but immediately know where the problem was. https://gettaurus.org/docs/PassFail/
A similar thing can be brought to the state of a killer feature


Nothing else provides this metric in Jmeter, for example InfluxDB contains only elapsed. But Jmeter collects these metrics, why should we ignore them?