### PR TITLE
feat: make buildTestElement method public for all TestElements;

### DIFF
--- a/jmeter-java-dsl-dashboard/src/main/java/us/abstracta/jmeter/javadsl/dashboard/DashboardVisualizer.java
+++ b/jmeter-java-dsl-dashboard/src/main/java/us/abstracta/jmeter/javadsl/dashboard/DashboardVisualizer.java
@@ -144,7 +144,7 @@ public class DashboardVisualizer extends DslVisualizer {
   }
 
   @Override
-  protected TestElement buildTestElement() {
+  public TestElement buildTestElement() {
     return null;
   }
 

--- a/jmeter-java-dsl-jdbc/src/main/java/us/abstracta/jmeter/javadsl/jdbc/DslJdbcConnectionPool.java
+++ b/jmeter-java-dsl-jdbc/src/main/java/us/abstracta/jmeter/javadsl/jdbc/DslJdbcConnectionPool.java
@@ -153,7 +153,7 @@ public class DslJdbcConnectionPool extends BaseConfigElement {
   }
 
   @Override
-  protected TestElement buildTestElement() {
+  public TestElement buildTestElement() {
     DataSourceElement ret = new DataSourceElement();
     ret.setDataSource(name);
     ret.setDriver(driverClass.getName());

--- a/jmeter-java-dsl-jdbc/src/main/java/us/abstracta/jmeter/javadsl/jdbc/DslJdbcSampler.java
+++ b/jmeter-java-dsl-jdbc/src/main/java/us/abstracta/jmeter/javadsl/jdbc/DslJdbcSampler.java
@@ -334,7 +334,7 @@ public class DslJdbcSampler extends BaseSampler<DslJdbcSampler> {
   }
 
   @Override
-  protected TestElement buildTestElement() {
+  public TestElement buildTestElement() {
     JDBCSampler ret = new JDBCSampler();
     ret.setQueryType(getQueryType().propertyValue);
     ret.setDataSource(poolName);

--- a/jmeter-java-dsl-parallel/src/main/java/us/abstracta/jmeter/javadsl/parallel/ParallelController.java
+++ b/jmeter-java-dsl-parallel/src/main/java/us/abstracta/jmeter/javadsl/parallel/ParallelController.java
@@ -128,7 +128,7 @@ public class ParallelController extends BaseController {
   }
 
   @Override
-  protected TestElement buildTestElement() {
+  public TestElement buildTestElement() {
     ParallelSampler ret = new ParallelSampler();
     ret.setGenerateParent(generateParent);
     if (maxThreads != null) {

--- a/jmeter-java-dsl-wrapper/src/main/java/us/abstracta/jmeter/javadsl/wrapper/wrappers/DslControllerWrapper.java
+++ b/jmeter-java-dsl-wrapper/src/main/java/us/abstracta/jmeter/javadsl/wrapper/wrappers/DslControllerWrapper.java
@@ -43,7 +43,7 @@ public class DslControllerWrapper extends BaseController implements
   }
 
   @Override
-  protected TestElement buildTestElement() {
+  public TestElement buildTestElement() {
     return helper.buildTestElement();
   }
 

--- a/jmeter-java-dsl-wrapper/src/main/java/us/abstracta/jmeter/javadsl/wrapper/wrappers/DslSamplerWrapper.java
+++ b/jmeter-java-dsl-wrapper/src/main/java/us/abstracta/jmeter/javadsl/wrapper/wrappers/DslSamplerWrapper.java
@@ -29,7 +29,7 @@ public class DslSamplerWrapper extends BaseSampler<DslSamplerWrapper> implements
   }
 
   @Override
-  protected TestElement buildTestElement() {
+  public TestElement buildTestElement() {
     return helper.buildTestElement();
   }
 

--- a/jmeter-java-dsl-wrapper/src/main/java/us/abstracta/jmeter/javadsl/wrapper/wrappers/MultiLevelTestElementWrapper.java
+++ b/jmeter-java-dsl-wrapper/src/main/java/us/abstracta/jmeter/javadsl/wrapper/wrappers/MultiLevelTestElementWrapper.java
@@ -32,7 +32,7 @@ public class MultiLevelTestElementWrapper extends BaseTestElement implements Mul
   }
 
   @Override
-  protected TestElement buildTestElement() {
+  public TestElement buildTestElement() {
     return helper.buildTestElement();
   }
 

--- a/jmeter-java-dsl/src/main/java/us/abstracta/jmeter/javadsl/core/DslTestPlan.java
+++ b/jmeter-java-dsl/src/main/java/us/abstracta/jmeter/javadsl/core/DslTestPlan.java
@@ -70,7 +70,7 @@ public class DslTestPlan extends TestElementContainer<TestPlanChild> {
   }
 
   @Override
-  protected TestElement buildTestElement() {
+  public TestElement buildTestElement() {
     TestPlan ret = new TestPlan();
     ret.setUserDefinedVariables(new Arguments());
     ret.setTearDownOnShutdown(this.tearDownAfterMainThreadsShutDown);

--- a/jmeter-java-dsl/src/main/java/us/abstracta/jmeter/javadsl/core/assertions/DslResponseAssertion.java
+++ b/jmeter-java-dsl/src/main/java/us/abstracta/jmeter/javadsl/core/assertions/DslResponseAssertion.java
@@ -216,7 +216,7 @@ public class DslResponseAssertion extends DslScopedTestElement<DslResponseAssert
   }
 
   @Override
-  protected TestElement buildTestElement() {
+  public TestElement buildTestElement() {
     ResponseAssertion ret = new ResponseAssertion();
     setScopeTo(ret);
     fieldToTest.applyTo(ret);

--- a/jmeter-java-dsl/src/main/java/us/abstracta/jmeter/javadsl/core/configs/DslCsvDataSet.java
+++ b/jmeter-java-dsl/src/main/java/us/abstracta/jmeter/javadsl/core/configs/DslCsvDataSet.java
@@ -145,7 +145,7 @@ public class DslCsvDataSet extends BaseConfigElement {
   }
 
   @Override
-  protected TestElement buildTestElement() {
+  public TestElement buildTestElement() {
     return randomOrder ? buildRandomCsvDataSet() : buildSimpleCsvDataSet();
   }
 

--- a/jmeter-java-dsl/src/main/java/us/abstracta/jmeter/javadsl/core/configs/DslVariables.java
+++ b/jmeter-java-dsl/src/main/java/us/abstracta/jmeter/javadsl/core/configs/DslVariables.java
@@ -67,7 +67,7 @@ public class DslVariables extends BaseConfigElement {
   }
 
   @Override
-  protected TestElement buildTestElement() {
+  public TestElement buildTestElement() {
     Arguments ret = new Arguments();
     for (Map.Entry<String, String> entry : vars.entrySet()) {
       ret.addArgument(entry.getKey(), entry.getValue());

--- a/jmeter-java-dsl/src/main/java/us/abstracta/jmeter/javadsl/core/controllers/DslForEachController.java
+++ b/jmeter-java-dsl/src/main/java/us/abstracta/jmeter/javadsl/core/controllers/DslForEachController.java
@@ -31,7 +31,7 @@ public class DslForEachController extends BaseController {
   }
 
   @Override
-  protected TestElement buildTestElement() {
+  public TestElement buildTestElement() {
     ForeachController ret = new ForeachController();
     ret.setInputVal(varsPrefix);
     ret.setReturnVal(iterationVarName);

--- a/jmeter-java-dsl/src/main/java/us/abstracta/jmeter/javadsl/core/controllers/DslIfController.java
+++ b/jmeter-java-dsl/src/main/java/us/abstracta/jmeter/javadsl/core/controllers/DslIfController.java
@@ -32,7 +32,7 @@ public class DslIfController extends BaseController {
   }
 
   @Override
-  protected TestElement buildTestElement() {
+  public TestElement buildTestElement() {
     IfController ret = new IfController();
     ret.setUseExpression(true);
     String condition = conditionBuilder.build();

--- a/jmeter-java-dsl/src/main/java/us/abstracta/jmeter/javadsl/core/controllers/DslOnceOnlyController.java
+++ b/jmeter-java-dsl/src/main/java/us/abstracta/jmeter/javadsl/core/controllers/DslOnceOnlyController.java
@@ -21,7 +21,7 @@ public class DslOnceOnlyController extends BaseController {
   }
 
   @Override
-  protected TestElement buildTestElement() {
+  public TestElement buildTestElement() {
     return new OnceOnlyController();
   }
 

--- a/jmeter-java-dsl/src/main/java/us/abstracta/jmeter/javadsl/core/controllers/DslRecordingController.java
+++ b/jmeter-java-dsl/src/main/java/us/abstracta/jmeter/javadsl/core/controllers/DslRecordingController.java
@@ -23,7 +23,7 @@ public class DslRecordingController extends BaseController {
   }
 
   @Override
-  protected TestElement buildTestElement() {
+  public TestElement buildTestElement() {
     throw new UnsupportedOperationException();
   }
 

--- a/jmeter-java-dsl/src/main/java/us/abstracta/jmeter/javadsl/core/controllers/DslTransactionController.java
+++ b/jmeter-java-dsl/src/main/java/us/abstracta/jmeter/javadsl/core/controllers/DslTransactionController.java
@@ -83,7 +83,7 @@ public class DslTransactionController extends BaseController {
   }
 
   @Override
-  protected TestElement buildTestElement() {
+  public TestElement buildTestElement() {
     TransactionController ret = new TransactionController();
     ret.setGenerateParentSample(generateParentSample);
     // we can't use setIncludeTimers since it ignores true values

--- a/jmeter-java-dsl/src/main/java/us/abstracta/jmeter/javadsl/core/controllers/DslWhileController.java
+++ b/jmeter-java-dsl/src/main/java/us/abstracta/jmeter/javadsl/core/controllers/DslWhileController.java
@@ -39,7 +39,7 @@ public class DslWhileController extends BaseController {
   }
 
   @Override
-  protected TestElement buildTestElement() {
+  public TestElement buildTestElement() {
     WhileController ret = new WhileController();
     String condition = conditionBuilder.build();
     ret.setCondition(condition);

--- a/jmeter-java-dsl/src/main/java/us/abstracta/jmeter/javadsl/core/controllers/ForLoopController.java
+++ b/jmeter-java-dsl/src/main/java/us/abstracta/jmeter/javadsl/core/controllers/ForLoopController.java
@@ -26,7 +26,7 @@ public class ForLoopController extends BaseController {
   }
 
   @Override
-  protected TestElement buildTestElement() {
+  public TestElement buildTestElement() {
     LoopController ret = new LoopController();
     ret.setLoops(count);
     return ret;

--- a/jmeter-java-dsl/src/main/java/us/abstracta/jmeter/javadsl/core/controllers/PercentController.java
+++ b/jmeter-java-dsl/src/main/java/us/abstracta/jmeter/javadsl/core/controllers/PercentController.java
@@ -31,7 +31,7 @@ public class PercentController extends BaseController {
   }
 
   @Override
-  protected TestElement buildTestElement() {
+  public TestElement buildTestElement() {
     ThroughputController ret = new ThroughputController();
     ret.setStyle(ThroughputController.BYPERCENT);
     ret.setPercentThroughput(percent);

--- a/jmeter-java-dsl/src/main/java/us/abstracta/jmeter/javadsl/core/listeners/DslBackendListener.java
+++ b/jmeter-java-dsl/src/main/java/us/abstracta/jmeter/javadsl/core/listeners/DslBackendListener.java
@@ -42,7 +42,7 @@ public abstract class DslBackendListener extends BaseListener {
   }
 
   @Override
-  protected TestElement buildTestElement() {
+  public TestElement buildTestElement() {
     BackendListener ret = new BackendListener();
     ret.setClassname(listenerClass.getName());
     ret.setQueueSize(String.valueOf(queueSize));

--- a/jmeter-java-dsl/src/main/java/us/abstracta/jmeter/javadsl/core/listeners/DslViewResultsTree.java
+++ b/jmeter-java-dsl/src/main/java/us/abstracta/jmeter/javadsl/core/listeners/DslViewResultsTree.java
@@ -61,7 +61,7 @@ public class DslViewResultsTree extends DslVisualizer {
   }
 
   @Override
-  protected TestElement buildTestElement() {
+  public TestElement buildTestElement() {
     return new ResultCollector();
   }
 

--- a/jmeter-java-dsl/src/main/java/us/abstracta/jmeter/javadsl/core/listeners/ResponseFileSaver.java
+++ b/jmeter-java-dsl/src/main/java/us/abstracta/jmeter/javadsl/core/listeners/ResponseFileSaver.java
@@ -28,7 +28,7 @@ public class ResponseFileSaver extends BaseListener {
   }
 
   @Override
-  protected TestElement buildTestElement() {
+  public TestElement buildTestElement() {
     ResultSaver ret = new ResultSaver();
     ret.setFilename(fileNamePrefix);
     return ret;

--- a/jmeter-java-dsl/src/main/java/us/abstracta/jmeter/javadsl/core/postprocessors/DslBoundaryExtractor.java
+++ b/jmeter-java-dsl/src/main/java/us/abstracta/jmeter/javadsl/core/postprocessors/DslBoundaryExtractor.java
@@ -82,7 +82,7 @@ public class DslBoundaryExtractor extends DslVariableExtractor<DslBoundaryExtrac
   }
 
   @Override
-  protected TestElement buildTestElement() {
+  public TestElement buildTestElement() {
     BoundaryExtractor ret = new BoundaryExtractor();
     setScopeTo(ret);
     ret.setUseField(fieldToCheck.propertyValue);

--- a/jmeter-java-dsl/src/main/java/us/abstracta/jmeter/javadsl/core/postprocessors/DslDebugPostProcessor.java
+++ b/jmeter-java-dsl/src/main/java/us/abstracta/jmeter/javadsl/core/postprocessors/DslDebugPostProcessor.java
@@ -103,7 +103,7 @@ public class DslDebugPostProcessor extends BaseTestElement implements DslPostPro
   }
 
   @Override
-  protected TestElement buildTestElement() {
+  public TestElement buildTestElement() {
     DebugPostProcessor ret = new DebugPostProcessor();
     ret.setDisplayJMeterVariables(includeVariables);
     ret.setDisplaySamplerProperties(includeSamplerProperties);

--- a/jmeter-java-dsl/src/main/java/us/abstracta/jmeter/javadsl/core/postprocessors/DslJsonExtractor.java
+++ b/jmeter-java-dsl/src/main/java/us/abstracta/jmeter/javadsl/core/postprocessors/DslJsonExtractor.java
@@ -62,7 +62,7 @@ public class DslJsonExtractor extends DslVariableExtractor<DslJsonExtractor> {
   }
 
   @Override
-  protected TestElement buildTestElement() {
+  public TestElement buildTestElement() {
     JMESPathExtractor ret = new JMESPathExtractor();
     setScopeTo(ret);
     ret.setRefName(varName);

--- a/jmeter-java-dsl/src/main/java/us/abstracta/jmeter/javadsl/core/postprocessors/DslRegexExtractor.java
+++ b/jmeter-java-dsl/src/main/java/us/abstracta/jmeter/javadsl/core/postprocessors/DslRegexExtractor.java
@@ -104,7 +104,7 @@ public class DslRegexExtractor extends DslVariableExtractor<DslRegexExtractor> {
   }
 
   @Override
-  protected TestElement buildTestElement() {
+  public TestElement buildTestElement() {
     RegexExtractor ret = new RegexExtractor();
     setScopeTo(ret);
     ret.setUseField(fieldToCheck.propertyValue);

--- a/jmeter-java-dsl/src/main/java/us/abstracta/jmeter/javadsl/core/samplers/DslDummySampler.java
+++ b/jmeter-java-dsl/src/main/java/us/abstracta/jmeter/javadsl/core/samplers/DslDummySampler.java
@@ -129,7 +129,7 @@ public class DslDummySampler extends BaseSampler<DslDummySampler> {
   }
 
   @Override
-  protected TestElement buildTestElement() {
+  public TestElement buildTestElement() {
     DummySampler ret = new DummySampler();
     DummyElement dummy = ret.getDummy();
     dummy.setResponseData(responseBody);

--- a/jmeter-java-dsl/src/main/java/us/abstracta/jmeter/javadsl/core/testelements/BaseTestElement.java
+++ b/jmeter-java-dsl/src/main/java/us/abstracta/jmeter/javadsl/core/testelements/BaseTestElement.java
@@ -78,7 +78,7 @@ public abstract class BaseTestElement implements DslTestElement {
     return ret;
   }
 
-  protected abstract TestElement buildTestElement();
+  public abstract TestElement buildTestElement();
 
   private static void loadBeanProperties(TestElement bean) {
     try {

--- a/jmeter-java-dsl/src/main/java/us/abstracta/jmeter/javadsl/core/testelements/DslJsr223TestElement.java
+++ b/jmeter-java-dsl/src/main/java/us/abstracta/jmeter/javadsl/core/testelements/DslJsr223TestElement.java
@@ -49,7 +49,7 @@ public abstract class DslJsr223TestElement extends BaseTestElement {
   }
 
   @Override
-  protected TestElement buildTestElement() {
+  public TestElement buildTestElement() {
     JSR223TestElement ret = buildJsr223TestElement();
     ret.setScriptLanguage(language);
     ret.setScript(scriptBuilder.build());

--- a/jmeter-java-dsl/src/main/java/us/abstracta/jmeter/javadsl/core/threadgroups/BaseThreadGroup.java
+++ b/jmeter-java-dsl/src/main/java/us/abstracta/jmeter/javadsl/core/threadgroups/BaseThreadGroup.java
@@ -54,7 +54,7 @@ public abstract class BaseThreadGroup<T extends BaseThreadGroup<?>> extends
   }
 
   @Override
-  protected TestElement buildTestElement() {
+  public TestElement buildTestElement() {
     TestElement ret = buildThreadGroup();
     ret.setProperty(
         new StringProperty(AbstractThreadGroup.ON_SAMPLE_ERROR, sampleErrorAction.propertyValue));

--- a/jmeter-java-dsl/src/main/java/us/abstracta/jmeter/javadsl/core/timers/DslUniformRandomTimer.java
+++ b/jmeter-java-dsl/src/main/java/us/abstracta/jmeter/javadsl/core/timers/DslUniformRandomTimer.java
@@ -32,7 +32,7 @@ public class DslUniformRandomTimer extends BaseTestElement implements DslTimer {
   }
 
   @Override
-  protected TestElement buildTestElement() {
+  public TestElement buildTestElement() {
     UniformRandomTimer urt = new UniformRandomTimer();
     urt.setRange(maximumMillis - minimumMillis);
     urt.setDelay(String.valueOf(minimumMillis));

--- a/jmeter-java-dsl/src/main/java/us/abstracta/jmeter/javadsl/http/DslBaseHttpSampler.java
+++ b/jmeter-java-dsl/src/main/java/us/abstracta/jmeter/javadsl/http/DslBaseHttpSampler.java
@@ -158,7 +158,7 @@ public abstract class DslBaseHttpSampler<T extends DslBaseHttpSampler<?>> extend
   }
 
   @Override
-  protected TestElement buildTestElement() {
+  public TestElement buildTestElement() {
     HTTPSamplerProxy ret = new HTTPSamplerProxy();
     if (protocol != null) {
       ret.setProtocol(protocol);

--- a/jmeter-java-dsl/src/main/java/us/abstracta/jmeter/javadsl/http/DslCacheManager.java
+++ b/jmeter-java-dsl/src/main/java/us/abstracta/jmeter/javadsl/http/DslCacheManager.java
@@ -34,7 +34,7 @@ public class DslCacheManager extends AutoEnabledHttpConfigElement {
   }
 
   @Override
-  protected TestElement buildTestElement() {
+  public TestElement buildTestElement() {
     CacheManager ret = new CacheManager();
     ret.setUseExpires(true);
     ret.setClearEachIteration(true);

--- a/jmeter-java-dsl/src/main/java/us/abstracta/jmeter/javadsl/http/DslCookieManager.java
+++ b/jmeter-java-dsl/src/main/java/us/abstracta/jmeter/javadsl/http/DslCookieManager.java
@@ -34,7 +34,7 @@ public class DslCookieManager extends AutoEnabledHttpConfigElement {
   }
 
   @Override
-  protected TestElement buildTestElement() {
+  public TestElement buildTestElement() {
     CookieManager ret = new CookieManager();
     ret.setClearEachIteration(true);
     return ret;

--- a/jmeter-java-dsl/src/main/java/us/abstracta/jmeter/javadsl/http/DslHttpDefaults.java
+++ b/jmeter-java-dsl/src/main/java/us/abstracta/jmeter/javadsl/http/DslHttpDefaults.java
@@ -184,7 +184,7 @@ public class DslHttpDefaults extends BaseConfigElement {
   }
 
   @Override
-  protected TestElement buildTestElement() {
+  public TestElement buildTestElement() {
     ConfigTestElement ret = new ConfigTestElement();
     if (protocol != null) {
       ret.setProperty(HTTPSamplerBase.PROTOCOL, protocol);

--- a/jmeter-java-dsl/src/main/java/us/abstracta/jmeter/javadsl/http/HttpHeaders.java
+++ b/jmeter-java-dsl/src/main/java/us/abstracta/jmeter/javadsl/http/HttpHeaders.java
@@ -72,7 +72,7 @@ public class HttpHeaders extends BaseConfigElement {
   }
 
   @Override
-  protected TestElement buildTestElement() {
+  public TestElement buildTestElement() {
     HeaderManager ret = new HeaderManager();
     headers.forEach((name, value) -> ret.add(new Header(name, value)));
     return ret;


### PR DESCRIPTION
I'd like to propose some massive but easy changes. 

 In my attempts to implement dsl for WeighedSwitchController (bzm plugin) I have stucked with inability to build TestElement from BaseTest element because it's under protected method.

So I don't see any problem to make public and give more flexibity to create new components.