### PR TITLE
cloneable samplers

### DIFF
--- a/jmeter-java-dsl/src/main/java/us/abstracta/jmeter/javadsl/core/testelements/BaseTestElement.java
+++ b/jmeter-java-dsl/src/main/java/us/abstracta/jmeter/javadsl/core/testelements/BaseTestElement.java
@@ -170,4 +170,11 @@ public abstract class BaseTestElement implements DslTestElement {
     return Math.round(Math.ceil((double) duration.toMillis() / 1000));
   }
 
+  public String getName() {
+    return this.name;
+  }
+
+  public void setName(String name) {
+    this.name = name;
+  }
 }

--- a/jmeter-java-dsl/src/main/java/us/abstracta/jmeter/javadsl/core/testelements/DslJsr223TestElement.java
+++ b/jmeter-java-dsl/src/main/java/us/abstracta/jmeter/javadsl/core/testelements/DslJsr223TestElement.java
@@ -46,6 +46,14 @@ public abstract class DslJsr223TestElement<T extends DslJsr223TestElement<T>> ex
         mapWithEntry("label", "Label", varsNameMapping));
   }
 
+  public DslScriptBuilder getScriptBuilder() {
+    return this.scriptBuilder;
+  }
+
+  public void setScriptBuilder(DslScriptBuilder scriptBuilder) {
+    this.scriptBuilder = scriptBuilder;
+  }
+
   private static <K, V> Map<K, V> mapWithEntry(K key, V value, Map<K, V> map) {
     HashMap<K, V> ret = new HashMap<>(map);
     ret.put(key, value);

--- a/jmeter-java-dsl/src/main/java/us/abstracta/jmeter/javadsl/core/testelements/TestElementContainer.java
+++ b/jmeter-java-dsl/src/main/java/us/abstracta/jmeter/javadsl/core/testelements/TestElementContainer.java
@@ -20,7 +20,7 @@ import us.abstracta.jmeter.javadsl.core.DslTestPlan;
 public abstract class TestElementContainer<T extends TestElementContainer<T, C>,
     C extends DslTestElement> extends BaseTestElement {
 
-  protected final List<C> children = new ArrayList<>();
+  protected List<C> children = new ArrayList<>();
 
   protected TestElementContainer(String name, Class<? extends JMeterGUIComponent> guiClass,
       List<C> children) {
@@ -41,4 +41,11 @@ public abstract class TestElementContainer<T extends TestElementContainer<T, C>,
     return ret;
   }
 
+  public List<C> getChildren() {
+    return this.children;
+  }
+
+  public void setChildren(List<C> children) {
+    this.children = children;
+  }
 }

--- a/jmeter-java-dsl/src/main/java/us/abstracta/jmeter/javadsl/http/DslBaseHttpSampler.java
+++ b/jmeter-java-dsl/src/main/java/us/abstracta/jmeter/javadsl/http/DslBaseHttpSampler.java
@@ -40,7 +40,7 @@ public abstract class DslBaseHttpSampler<T extends DslBaseHttpSampler<T>> extend
       "httpclient.reset_state_on_thread_group_iteration";
 
   protected String path;
-  protected final HttpHeaders headers = new HttpHeaders();
+  protected HttpHeaders headers = new HttpHeaders();
   protected String protocol;
   protected String host;
   protected String port;
@@ -58,6 +58,22 @@ public abstract class DslBaseHttpSampler<T extends DslBaseHttpSampler<T>> extend
     host = parsedUrl.host();
     port = parsedUrl.port();
     path = parsedUrl.path();
+  }
+
+  public String getPath() {
+    return this.path;
+  }
+
+  public void setPath(String path) {
+    this.path = path;
+  }
+
+  public HttpHeaders getHeaders() {
+    return this.headers;
+  }
+
+  public void setHeaders(HttpHeaders headers) {
+    this.headers = headers;
   }
 
   /**

--- a/jmeter-java-dsl/src/main/java/us/abstracta/jmeter/javadsl/http/DslHttpSampler.java
+++ b/jmeter-java-dsl/src/main/java/us/abstracta/jmeter/javadsl/http/DslHttpSampler.java
@@ -68,6 +68,31 @@ public class DslHttpSampler extends DslBaseHttpSampler<DslHttpSampler> {
         ));
   }
 
+  public String getMethod() {
+    return this.method;
+  }
+
+  public void setMethod(String method) {
+    this.method = method;
+  }
+
+  public String getBody() {
+    return this.body;
+  }
+
+  public void setBody(String body) {
+    this.body = body;
+  }
+
+  public DslHttpSampler clone() {
+    DslHttpSampler newSampler = new DslHttpSampler(this.getName(), this.getPath());
+    newSampler.setMethod(this.getMethod());
+    newSampler.setBody(this.getBody());
+    newSampler.setHeaders(this.getHeaders());
+    newSampler.setChildren(this.getChildren());
+    return newSampler;
+  }
+
   /**
    * Specifies that the sampler should send an HTTP POST to defined URL.
    *

--- a/jmeter-java-dsl/src/main/java/us/abstracta/jmeter/javadsl/java/DslJsr223Sampler.java
+++ b/jmeter-java-dsl/src/main/java/us/abstracta/jmeter/javadsl/java/DslJsr223Sampler.java
@@ -35,7 +35,7 @@ public class DslJsr223Sampler extends DslJsr223TestElement<DslJsr223Sampler> imp
 
   private static final String DEFAULT_NAME = "JSR223 Sampler";
 
-  protected final List<SamplerChild> children = new ArrayList<>();
+  protected List<SamplerChild> children = new ArrayList<>();
 
   public DslJsr223Sampler(String name, String script) {
     super(name, DEFAULT_NAME, script);
@@ -44,6 +44,21 @@ public class DslJsr223Sampler extends DslJsr223TestElement<DslJsr223Sampler> imp
   public DslJsr223Sampler(String name, SamplerScript script) {
     super(name, DEFAULT_NAME, script, SamplerVars.class,
         Collections.singletonMap("sampleResult", "SampleResult"));
+  }
+
+  public List<SamplerChild> getChildren() {
+    return this.children;
+  }
+
+  public void setChildren(List<SamplerChild> children) {
+    this.children = children;
+  }
+
+  public DslJsr223Sampler clone() {
+    DslJsr223Sampler newSampler = new DslJsr223Sampler(this.getName(), "");
+    newSampler.setScriptBuilder(this.getScriptBuilder());
+    newSampler.setChildren(this.getChildren());
+    return newSampler;
   }
 
   /**


### PR DESCRIPTION
The main reason for this change - to get a sampler name. The second reason - to get a cloned sampler.
So I added getters and setters for fields in classes: DslBaseHttpSampler, DslHttpSampler, DslJsr223Sampler, DslJsr223TestElement, TestElementContainer, BaseTestElement. And I added method clone() in classes: DslHttpSampler, DslJsr223Sampler. Also I deleted attribute 'final' for fields 'children' and 'headers', so later I could filter sampler children for cloned object (for example, I need cloned sampler without origin sampler postprocessors).