### PR TITLE
Expose Additional JMeter Result Saver Properties in the DSL

### DIFF
--- a/jmeter-java-dsl/src/main/java/us/abstracta/jmeter/javadsl/core/listeners/ResponseFileSaver.java
+++ b/jmeter-java-dsl/src/main/java/us/abstracta/jmeter/javadsl/core/listeners/ResponseFileSaver.java
@@ -20,7 +20,8 @@ import us.abstracta.jmeter.javadsl.codegeneration.TestElementParamBuilder;
  * <p>
  * By default, it will generate one file for each response using the given (which might include the
  * directory location) prefix to create the files and adding an incremental number to each response
- * and an extension according to the response mime type.
+ * and an extension according to the response mime type. Both the incremental number and the
+ * extension can be set manually if skipAutoNumber and skipSuffix are set to true respectively.
  *
  * @since 0.13
  */

--- a/jmeter-java-dsl/src/main/java/us/abstracta/jmeter/javadsl/core/listeners/ResponseFileSaver.java
+++ b/jmeter-java-dsl/src/main/java/us/abstracta/jmeter/javadsl/core/listeners/ResponseFileSaver.java
@@ -27,6 +27,8 @@ import us.abstracta.jmeter.javadsl.codegeneration.TestElementParamBuilder;
 public class ResponseFileSaver extends BaseListener {
 
   protected String fileNamePrefix;
+  protected boolean skipAutoNumber = false;
+  protected boolean skipSuffix = false;
 
   public ResponseFileSaver(String fileNamePrefix) {
     super("Save Responses to a file", ResultSaverGui.class);
@@ -37,7 +39,17 @@ public class ResponseFileSaver extends BaseListener {
   protected TestElement buildTestElement() {
     ResultSaver ret = new ResultSaver();
     ret.setFilename(fileNamePrefix);
+    ret.setSkipAutoNumber(skipAutoNumber);
+    ret.setSkipSuffix(skipSuffix);
     return ret;
+  }
+
+  public void setSkipAutoNumber(boolean skipAutoNumber) {
+    this.skipAutoNumber = skipAutoNumber;
+  }
+
+  public void setSkipSuffix(boolean  skipSuffix) {
+    this.skipSuffix = skipSuffix;
   }
 
   public static class CodeBuilder extends SingleTestElementCallBuilder<ResultSaver> {
@@ -49,7 +61,7 @@ public class ResponseFileSaver extends BaseListener {
     @Override
     protected MethodCall buildMethodCall(ResultSaver testElement, MethodCallContext context) {
       return buildMethodCall(
-          new TestElementParamBuilder(testElement).stringParam(ResultSaver.FILENAME));
+              new TestElementParamBuilder(testElement).stringParam(ResultSaver.FILENAME));
     }
 
   }

--- a/jmeter-java-dsl/src/main/java/us/abstracta/jmeter/javadsl/core/listeners/ResponseFileSaver.java
+++ b/jmeter-java-dsl/src/main/java/us/abstracta/jmeter/javadsl/core/listeners/ResponseFileSaver.java
@@ -45,12 +45,34 @@ public class ResponseFileSaver extends BaseListener {
     return ret;
   }
 
-  public void setSkipAutoNumber(boolean skipAutoNumber) {
+
+  /**
+   * Allows specifying whether the ResponseFileSaver appends a number to the end of the generated file.
+   * <p>
+   * By default, the ResponseFileSaver will add a number based on the samplers in the scope of the 
+   * ResponseFileSaver test element. If set to true then no number will be appended.
+   *
+   * @param skipAutoNumber Boolean determining whether the number is added.
+   * @return the ResponseFileSaver for further configuration or usage.
+   */
+  public ResponseFileSaver setSkipAutoNumber(boolean skipAutoNumber) {
     this.skipAutoNumber = skipAutoNumber;
+    return this;
   }
 
-  public void setSkipSuffix(boolean  skipSuffix) {
+
+  /**
+   * Allows specifying whether the ResponseFileSaver will append the file type to the file name.
+   * <p>
+   * By default, the ResponseFileSaver will use the MIME type to append the file type to the end of the
+   * generated file. If this is set to true then no file type will be appended.
+   * 
+   * @param skipSuffix Boolean determining whether a file type is added.
+   * @return the ResponseFileSaver for further configuration or usage.
+   */
+  public ResponseFileSaver setSkipSuffix(boolean  skipSuffix) {
     this.skipSuffix = skipSuffix;
+    return this;
   }
 
   public static class CodeBuilder extends SingleTestElementCallBuilder<ResultSaver> {

--- a/jmeter-java-dsl/src/test/java/us/abstracta/jmeter/javadsl/core/listeners/ResponseFileSaverTest.java
+++ b/jmeter-java-dsl/src/test/java/us/abstracta/jmeter/javadsl/core/listeners/ResponseFileSaverTest.java
@@ -36,6 +36,37 @@ public class ResponseFileSaverTest extends JmeterDslTest {
   }
 
   @Test
+  public void shouldWriteFileWithNoAddedNumberWithResponseContentWhenResponseFileSaverInPlanAndSkipAutoNumberTrue(@TempDir Path tempDir) throws Exception {
+    String body = "TEST BODY";
+    ResponseFileSaver fileSaver = responseFileSaver(tempDir.resolve(RESPONSE_FILE_PREFIX).toString());
+    fileSaver.setSkipAutoNumber(true);
+    stubFor(any(anyUrl()).willReturn(aResponse().withBody(body)));
+    testPlan(
+            threadGroup(1, 1,
+                    httpSampler(wiremockUri)
+            ),
+            fileSaver
+    ).run();
+    assertThat(tempDir.resolve("response.unknown")).hasContent(body);
+  }
+
+  @Test
+  public void shouldWriteFileWithNoAddedFileExtensionWithResponseContentWhenResponseFileSaverInPlanAndSkipAutoNumberTrue(@TempDir Path tempDir) throws Exception {
+    String body = "TEST BODY";
+    ResponseFileSaver fileSaver = responseFileSaver(tempDir.resolve(RESPONSE_FILE_PREFIX).toString());
+    fileSaver.setSkipSuffix(true);
+    stubFor(any(anyUrl()).willReturn(aResponse().withBody(body)));
+    testPlan(
+            threadGroup(1, 1,
+                    httpSampler(wiremockUri)
+            ),
+            fileSaver
+    ).run();
+    assertThat(tempDir.resolve("response1")).hasContent(body);
+  }
+
+
+  @Test
   public void shouldWriteOneFileForEachResponseWhenResponseFileSaverInPlan(@TempDir Path tempDir) throws Exception {
     testPlan(
         threadGroup(1, TEST_ITERATIONS,


### PR DESCRIPTION
Reason for change: The naming pattern used by the JMeter ResponseFileSaver listener is a little bit weird when running on its default settings. This change exposes the variables that allow you to make file naming explicit as additional properties that can be set after construction. 