### PR TITLE
Add random choice support for WeightedSwitchController

### DIFF
--- a/jmeter-java-dsl/src/main/java/us/abstracta/jmeter/javadsl/core/controllers/DslWeightedSwitchController.java
+++ b/jmeter-java-dsl/src/main/java/us/abstracta/jmeter/javadsl/core/controllers/DslWeightedSwitchController.java
@@ -44,6 +44,7 @@ import us.abstracta.jmeter.javadsl.core.threadgroups.BaseThreadGroup.ThreadGroup
 public class DslWeightedSwitchController extends BaseController<DslWeightedSwitchController> {
 
   public static final long DEFAULT_WEIGHT = 100;
+  private boolean isRandomChoice = false;
 
   public DslWeightedSwitchController() {
     super("Weighted Switch Controller", WeightedSwitchControllerGui.class, new ArrayList<>());
@@ -78,6 +79,11 @@ public class DslWeightedSwitchController extends BaseController<DslWeightedSwitc
    */
   public DslWeightedSwitchController child(long weight, DslSampler child) {
     return addWeightedChild(weight, child);
+  }
+
+  public DslWeightedSwitchController isRandomChoice(){
+    this.isRandomChoice = true;
+    return this;
   }
 
   private DslWeightedSwitchController addWeightedChild(long weight, ThreadGroupChild child) {
@@ -144,6 +150,7 @@ public class DslWeightedSwitchController extends BaseController<DslWeightedSwitc
       }
     }
     controller.setData(model);
+    controller.setIsRandomChoice(isRandomChoice);
     return ret;
   }
 


### PR DESCRIPTION
[WeightedSwitchController.md](https://github.com/Blazemeter/jmeter-bzm-plugins/blob/master/wsc/WeightedSwitchController.md?utm_source=jmeter&utm_medium=helplink&utm_campaign=WeightedSwitchController)
> Random Choice - on each iteration plugin will choose a random item. This check box can not guarantee that actual percent of child elements execution will equals with expected (delta in tests not more than 0.5%)


- Added `isRandomChoice()` method to DslWeightedSwitchController to enable random selection of child elements
- Added test case to verify random choice functionality

weightedSwitchController()
                            .child(weight1, httpSampler(SAMPLE_1_LABEL, wiremockUri))
                            .children(httpSampler(SAMPLE_2_LABEL, wiremockUri))
                            .child(weight2, httpSampler(label3, wiremockUri))
                            **.isRandomChoice()**

![2025-06-17 00 01 27](https://github.com/user-attachments/assets/338f0070-0af0-4e91-b712-6e84ce33b111)

