### PR TITLE
Add support for connection Keep-Alive

### DIFF
--- a/docs/guide/protocols/http/index.md
+++ b/docs/guide/protocols/http/index.md
@@ -14,6 +14,7 @@ Here we show some of them, but check [JmeterDsl](/jmeter-java-dsl/src/main/java/
 <!-- @include: connections.md -->
 <!-- @include: embedded-resources.md -->
 <!-- @include: redirects.md -->
+<!-- @include: keepAlive.md -->
 <!-- @include: defaults.md -->
 <!-- @include: override-defaults.md -->
 <!-- @include: proxy.md -->

--- a/docs/guide/protocols/http/keepAlive.md
+++ b/docs/guide/protocols/http/keepAlive.md
@@ -1,0 +1,39 @@
+#### Keep alive
+
+Jmeter-java-dsl maintains a persistent http connection for subsequent requests to the same server.
+It is done by sending `Connection: keep-alive` header.
+If you want to disable keep-alive logic and force a server to close connection after each request then use`.useKeepAlive(false)` in a given `httpSampler` or `httpDefaults`.
+
+
+```java
+import static us.abstracta.jmeter.javadsl.JmeterDsl.*;
+import org.junit.jupiter.api.Test;
+public class PerformanceTest {
+
+  @Test
+  public void test1() throws Exception {
+    testPlan(
+        threadGroup(1, 10,
+            httpSampler("https://myservice1.com")
+                .useKeepAlive(false), 
+            httpSampler("https://myservice2.com")
+                .useKeepAlive(true),
+            httpSampler("https://myservice3.com")
+        )
+    ).run();
+  }
+
+  @Test
+  public void test2() throws Exception {      
+    testPlan(
+        httpDefaults()
+            .useKeepAlive(false), 
+        threadGroup(1, 10,
+            httpSampler("https://myservice1.com"),
+            httpSampler("https://myservice2.com")
+       )
+    ).run();
+  }
+
+}
+```

--- a/jmeter-java-dsl/src/test/java/us/abstracta/jmeter/javadsl/http/DslHttpDefaultsTest.java
+++ b/jmeter-java-dsl/src/test/java/us/abstracta/jmeter/javadsl/http/DslHttpDefaultsTest.java
@@ -7,6 +7,8 @@ import static com.github.tomakehurst.wiremock.client.WireMock.getRequestedFor;
 import static com.github.tomakehurst.wiremock.client.WireMock.stubFor;
 import static com.github.tomakehurst.wiremock.client.WireMock.urlPathEqualTo;
 import static com.github.tomakehurst.wiremock.client.WireMock.verify;
+import static com.github.tomakehurst.wiremock.client.WireMock.anyUrl;
+import static com.github.tomakehurst.wiremock.client.WireMock.equalTo;
 import static org.assertj.core.api.Assertions.assertThat;
 import static us.abstracta.jmeter.javadsl.JmeterDsl.httpDefaults;
 import static us.abstracta.jmeter.javadsl.JmeterDsl.httpSampler;
@@ -203,6 +205,19 @@ public class DslHttpDefaultsTest extends JmeterDslTest {
     stubFor(get("/").willReturn(
         aResponse().withStatus(HttpStatus.SC_MOVED_PERMANENTLY)
             .withHeader("Location", wiremockUri + redirectPath)));
+  }
+
+  @Test
+  public void shouldNotSendConnectionKeepAliveWhenDisabledInDefaultsAndNotSettingInSampler()
+          throws Exception {
+    testPlan(
+       httpDefaults()
+           .useKeepAlive(false),
+       threadGroup(1, 1,
+           httpSampler(wiremockUri)
+       )
+    ).run();
+    verify(getRequestedFor(anyUrl()).withHeader("Connection", equalTo("close")));
   }
 
   @Test

--- a/jmeter-java-dsl/src/test/java/us/abstracta/jmeter/javadsl/http/DslHttpSamplerTest.java
+++ b/jmeter-java-dsl/src/test/java/us/abstracta/jmeter/javadsl/http/DslHttpSamplerTest.java
@@ -113,6 +113,18 @@ public class DslHttpSamplerTest extends JmeterDslTest {
   }
 
   @Test
+  public void shouldNotSendConnectionKeepAliveWhenHttpSamplerWithDisabledKeepAlive()
+      throws Exception {
+    testPlan(
+        threadGroup(1, 1,
+            httpSampler(wiremockUri)
+                .useKeepAlive(false)
+        )
+    ).run();
+    verify(getRequestedFor(anyUrl()).withHeader("Connection", equalTo("close")));
+  }
+
+  @Test
   public void shouldSendHeadersWhenHttpSamplerWithHeaders() throws Exception {
     testPlan(
         threadGroup(1, 1,
@@ -642,6 +654,15 @@ public class DslHttpSamplerTest extends JmeterDslTest {
           threadGroup(1, 1,
               httpSampler("http://localhost")
                   .followRedirects(false)
+          )
+      );
+    }
+
+    public DslTestPlan testPlanWithHttpGetNotUsingKeepAlive() {
+      return testPlan(
+          threadGroup(1, 1,
+              httpSampler("http://localhost")
+                  .useKeepAlive(false)
           )
       );
     }


### PR DESCRIPTION
Reason for change: I am making the keepAlive option available for DslHttpSampler and DslHttpDefaults. This functionality is well known in JMeter and often used to disable persistent server connection. 