### PR TITLE
feat: add resetOnEachIteration option to DslCounter

### DIFF
--- a/docs/guide/request-generation/counter.md
+++ b/docs/guide/request-generation/counter.md
@@ -13,5 +13,5 @@ testPlan(
     )
 ).run();
 ```
-
+You can also use `.resetOnEachIteration(true)` if you need the counter to reset to its starting value at the beginning of each new Thread Group iteration.
 Check [DslCounter](/jmeter-java-dsl/src/main/java/us/abstracta/jmeter/javadsl/core/configs/DslCounter.java) for more details.

--- a/jmeter-java-dsl/src/main/java/us/abstracta/jmeter/javadsl/core/configs/DslCounter.java
+++ b/jmeter-java-dsl/src/main/java/us/abstracta/jmeter/javadsl/core/configs/DslCounter.java
@@ -110,14 +110,17 @@ public class DslCounter extends BaseConfigElement {
    */
   public DslCounter resetOnEachIteration(boolean resetOnEachIteration) {
     this.resetOnEachIteration = resetOnEachIteration;
-    if (resetOnEachIteration) {
-      this.perThread = true;
-    }
     return this;
   }
 
   @Override
   protected TestElement buildTestElement() {
+    if (resetOnEachIteration && !perThread) {
+      throw new IllegalStateException(
+              "Invalid counter configuration: resetOnEachIteration(true) only works with perThread(true). A shared " +
+                      "counter (perThread=false) has no per-thread state, so it cannot reset on each iteration."
+      );
+    }
     CounterConfig ret = new CounterConfig();
     ret.setVarName(varName);
     ret.setStart(start);

--- a/jmeter-java-dsl/src/main/java/us/abstracta/jmeter/javadsl/core/configs/DslCounter.java
+++ b/jmeter-java-dsl/src/main/java/us/abstracta/jmeter/javadsl/core/configs/DslCounter.java
@@ -143,7 +143,7 @@ public class DslCounter extends BaseConfigElement {
       ret.chain("increment", paramBuilder.longParam("incr", 1L));
       ret.chain("maximumValue", paramBuilder.longParam("end", Long.MAX_VALUE));
       ret.chain("perThread", paramBuilder.boolParam("per_user", false));
-      ret.chain("resetOnEachIteration", paramBuilder.boolParam("reset_on_each_iteration", false));
+      ret.chain("resetOnEachIteration", paramBuilder.boolParam("reset_on_tg_iteration", false));
       return ret;
     }
 

--- a/jmeter-java-dsl/src/main/java/us/abstracta/jmeter/javadsl/core/configs/DslCounter.java
+++ b/jmeter-java-dsl/src/main/java/us/abstracta/jmeter/javadsl/core/configs/DslCounter.java
@@ -24,6 +24,7 @@ public class DslCounter extends BaseConfigElement {
   private long increment = 1;
   private long max = Long.MAX_VALUE;
   private boolean perThread = false;
+  private boolean resetOnEachIteration = false;
 
   public DslCounter(String varName) {
     super(varName, CounterConfigGui.class);
@@ -98,6 +99,23 @@ public class DslCounter extends BaseConfigElement {
     return this;
   }
 
+  /**
+   * Specifies whether to reset the counter value at the beginning of each thread group iteration.
+   *
+   * @param resetOnEachIteration specifies to reset the counter when a new thread group iteration
+   *                             starts. When not specified (set to false), the counter persists its
+   *                             value across different iterations. By default, it is set to false.
+   * @return the counter for further configuration and usage.
+   * @since 2.3
+   */
+  public DslCounter resetOnEachIteration(boolean resetOnEachIteration) {
+    this.resetOnEachIteration = resetOnEachIteration;
+    if (resetOnEachIteration) {
+      this.perThread = true;
+    }
+    return this;
+  }
+
   @Override
   protected TestElement buildTestElement() {
     CounterConfig ret = new CounterConfig();
@@ -106,6 +124,7 @@ public class DslCounter extends BaseConfigElement {
     ret.setIncrement(increment);
     ret.setEnd(max);
     ret.setIsPerUser(perThread);
+    ret.setResetOnThreadGroupIteration(resetOnEachIteration);
     return ret;
   }
 
@@ -124,6 +143,7 @@ public class DslCounter extends BaseConfigElement {
       ret.chain("increment", paramBuilder.longParam("incr", 1L));
       ret.chain("maximumValue", paramBuilder.longParam("end", Long.MAX_VALUE));
       ret.chain("perThread", paramBuilder.boolParam("per_user", false));
+      ret.chain("resetOnEachIteration", paramBuilder.boolParam("reset_on_each_iteration", false));
       return ret;
     }
 

--- a/jmeter-java-dsl/src/test/java/us/abstracta/jmeter/javadsl/core/configs/DslCounterTest.java
+++ b/jmeter-java-dsl/src/test/java/us/abstracta/jmeter/javadsl/core/configs/DslCounterTest.java
@@ -50,6 +50,24 @@ public class DslCounterTest extends JmeterDslTest {
     verify(threads, getRequestedFor(urlEqualTo("/" + (startingValue + increment))));
   }
 
+  @Test
+  public void shouldResetCounterOnEachIterationWhenResetOptionIsEnabled() throws Exception {
+    int startingValue = 1;
+    int increment = 1;
+    int threads = 1;
+    testPlan(
+            threadGroup(threads, 2,
+            counter("MY_COUNTER")
+                    .startingValue(startingValue)
+                    .increment(increment)
+                    .resetOnEachIteration(true),
+                    httpSampler(wiremockUri + "/${MY_COUNTER}")
+            )
+    ).run();
+    verify(2, getRequestedFor(urlEqualTo("/1")));
+    verify(0, getRequestedFor(urlEqualTo("/2")));
+  }
+
   @Nested
   public class CodeBuilderTest extends MethodCallBuilderTest {
 

--- a/jmeter-java-dsl/src/test/java/us/abstracta/jmeter/javadsl/core/configs/DslCounterTest.java
+++ b/jmeter-java-dsl/src/test/java/us/abstracta/jmeter/javadsl/core/configs/DslCounterTest.java
@@ -60,6 +60,7 @@ public class DslCounterTest extends JmeterDslTest {
             counter("MY_COUNTER")
                     .startingValue(startingValue)
                     .increment(increment)
+                    .perThread(true)
                     .resetOnEachIteration(true),
                     httpSampler(wiremockUri + "/${MY_COUNTER}")
             )


### PR DESCRIPTION
## Description
This PR introduces the `resetOnEachIteration(boolean)` API method to `DslCounter`.

Currently, `DslCounter` wraps JMeter's native `CounterConfig` but does not expose its built-in capability to reset the counter on each Thread Group iteration. Adding this option allows users to cleanly reset sequence variables on loop boundaries without needing custom JSR223 pre-processors.

To improve user experience and prevent common configuration errors, calling `.resetOnEachIteration(true)` will also automatically enable `.perThread(true)`, as JMeter requires per-thread tracking for this feature to work.

## Changes
- Added the `resetOnEachIteration(boolean)` method to `DslCounter`.
- Mapped the property to the underlying `CounterConfig.setResetOnThreadGroupIteration()` for both test execution and GUI generation.
- Updated the `CodeBuilder` to support generating this new method from JMX files.
- Added a unit test in `DslCounterTest` to verify the counter reset behaviour.
- Updated the user guide to include the new feature.